### PR TITLE
add required boost include for 1.59+

### DIFF
--- a/include/nodelet_rosbag/nodelet_rosbag.h
+++ b/include/nodelet_rosbag/nodelet_rosbag.h
@@ -2,6 +2,7 @@
 #define NODELET_ROSBAG_H
 
 #include <boost/thread/mutex.hpp>
+#include <boost/utility/in_place_factory.hpp>
 #include <nodelet/nodelet.h>
 #include <rosbag/bag.h>
 #include <topic_tools/shape_shifter.h>


### PR DESCRIPTION
boost::in_place needs additional includes in newer boost versions.